### PR TITLE
Build package for x86_64 specific CPU feature sets (v1, v3 and v4)

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,36 +8,100 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython:
-        CONFIG: linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython
+      linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.10.____cpython:
+        CONFIG: linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython:
-        CONFIG: linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython
+      linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.11.____cpython:
+        CONFIG: linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython:
-        CONFIG: linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython
+      linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.12.____cpython:
+        CONFIG: linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313:
-        CONFIG: linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313
+      linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.13.____cp313:
+        CONFIG: linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.10.____cpython:
-        CONFIG: linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.10.____cpython
+      linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.10.____cpython:
+        CONFIG: linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.11.____cpython:
-        CONFIG: linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.11.____cpython
+      linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.11.____cpython:
+        CONFIG: linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.12.____cpython:
-        CONFIG: linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.12.____cpython
+      linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.12.____cpython:
+        CONFIG: linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.13.____cp313:
-        CONFIG: linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.13.____cp313
+      linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.13.____cp313:
+        CONFIG: linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.10.____cpython:
+        CONFIG: linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.11.____cpython:
+        CONFIG: linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.12.____cpython:
+        CONFIG: linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.13.____cp313:
+        CONFIG: linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.10.____cpython:
+        CONFIG: linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.11.____cpython:
+        CONFIG: linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.12.____cpython:
+        CONFIG: linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.13.____cp313:
+        CONFIG: linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.10.____cpython:
+        CONFIG: linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.11.____cpython:
+        CONFIG: linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.12.____cpython:
+        CONFIG: linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.13.____cp313:
+        CONFIG: linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.10.____cpython:
+        CONFIG: linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.11.____cpython:
+        CONFIG: linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.12.____cpython:
+        CONFIG: linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.13.____cp313:
+        CONFIG: linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython:
@@ -104,6 +168,7 @@ jobs:
         CONFIG: linux_ppc64le_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+    maxParallel: 31
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,17 +8,41 @@ jobs:
     vmImage: macOS-13
   strategy:
     matrix:
-      osx_64_python3.10.____cpython:
-        CONFIG: osx_64_python3.10.____cpython
+      osx_64_microarch_level1python3.10.____cpython:
+        CONFIG: osx_64_microarch_level1python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_python3.11.____cpython:
-        CONFIG: osx_64_python3.11.____cpython
+      osx_64_microarch_level1python3.11.____cpython:
+        CONFIG: osx_64_microarch_level1python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_python3.12.____cpython:
-        CONFIG: osx_64_python3.12.____cpython
+      osx_64_microarch_level1python3.12.____cpython:
+        CONFIG: osx_64_microarch_level1python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_python3.13.____cp313:
-        CONFIG: osx_64_python3.13.____cp313
+      osx_64_microarch_level1python3.13.____cp313:
+        CONFIG: osx_64_microarch_level1python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+      osx_64_microarch_level3python3.10.____cpython:
+        CONFIG: osx_64_microarch_level3python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_microarch_level3python3.11.____cpython:
+        CONFIG: osx_64_microarch_level3python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_microarch_level3python3.12.____cpython:
+        CONFIG: osx_64_microarch_level3python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_microarch_level3python3.13.____cp313:
+        CONFIG: osx_64_microarch_level3python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+      osx_64_microarch_level4python3.10.____cpython:
+        CONFIG: osx_64_microarch_level4python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_microarch_level4python3.11.____cpython:
+        CONFIG: osx_64_microarch_level4python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_microarch_level4python3.12.____cpython:
+        CONFIG: osx_64_microarch_level4python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_microarch_level4python3.13.____cp313:
+        CONFIG: osx_64_microarch_level4python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
       osx_arm64_python3.10.____cpython:
         CONFIG: osx_arm64_python3.10.____cpython
@@ -32,6 +56,7 @@ jobs:
       osx_arm64_python3.13.____cp313:
         CONFIG: osx_arm64_python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
+    maxParallel: 12
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -32,6 +32,7 @@ jobs:
       win_64_cuda_compiler_versionNonepython3.13.____cp313:
         CONFIG: win_64_cuda_compiler_versionNonepython3.13.____cp313
         UPLOAD_PACKAGES: 'True'
+    maxParallel: 6
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,17 +15,19 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.6'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '14'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:
@@ -33,7 +35,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.10.* *_cpython
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,11 +15,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- '12.6'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
@@ -35,9 +35,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.11.* *_cpython
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.12.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,11 +15,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- '12.6'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
@@ -35,9 +35,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.12.* *_cpython
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.13.____cp313.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,11 +15,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- '12.6'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.13.* *_cp313
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.10.____cpython.yaml
@@ -1,15 +1,13 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '19'
+- '13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,17 +15,19 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.6'
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '19'
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
-macos_machine:
-- x86_64-apple-darwin13.4.0
+microarch_level:
+- '3'
 numpy:
 - '2'
 pin_run_as_build:
@@ -35,9 +35,10 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.10.* *_cpython
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,11 +15,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- '12.6'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
@@ -27,7 +27,7 @@ libblas:
 liblapacke:
 - 3.9.* *netlib
 microarch_level:
-- '1'
+- '3'
 numpy:
 - '2'
 pin_run_as_build:
@@ -35,9 +35,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.11.* *_cpython
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.12.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,11 +15,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- '12.6'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
@@ -27,7 +27,7 @@ libblas:
 liblapacke:
 - 3.9.* *netlib
 microarch_level:
-- '1'
+- '3'
 numpy:
 - '2'
 pin_run_as_build:
@@ -35,9 +35,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.12.* *_cpython
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.13.____cp313.yaml
@@ -1,15 +1,13 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '19'
+- '13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,17 +15,19 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.6'
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '19'
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
-macos_machine:
-- x86_64-apple-darwin13.4.0
+microarch_level:
+- '3'
 numpy:
 - '2'
 pin_run_as_build:
@@ -35,9 +35,10 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.13.* *_cp313
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.10.____cpython.yaml
@@ -1,15 +1,13 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '19'
+- '13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,17 +15,19 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.6'
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '19'
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
-macos_machine:
-- x86_64-apple-darwin13.4.0
+microarch_level:
+- '4'
 numpy:
 - '2'
 pin_run_as_build:
@@ -37,7 +37,8 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,11 +15,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- '12.6'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
@@ -27,7 +27,7 @@ libblas:
 liblapacke:
 - 3.9.* *netlib
 microarch_level:
-- '1'
+- '4'
 numpy:
 - '2'
 pin_run_as_build:
@@ -35,9 +35,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.11.* *_cpython
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.12.____cpython.yaml
@@ -1,15 +1,13 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '19'
+- '13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,17 +15,19 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.6'
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '19'
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
-macos_machine:
-- x86_64-apple-darwin13.4.0
+microarch_level:
+- '4'
 numpy:
 - '2'
 pin_run_as_build:
@@ -35,9 +35,10 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.12.* *_cpython
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.13.____cp313.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,17 +15,19 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.6'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '14'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '4'
 numpy:
 - '2'
 pin_run_as_build:
@@ -33,7 +35,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.13.* *_cp313
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,11 +15,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
@@ -35,9 +35,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.10.* *_cpython
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,11 +15,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
@@ -35,9 +35,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.11.* *_cpython
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.12.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,11 +15,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
@@ -35,9 +35,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.12.* *_cpython
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.13.____cp313.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,11 +15,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.13.* *_cp313
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,11 +15,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
@@ -27,7 +27,7 @@ libblas:
 liblapacke:
 - 3.9.* *netlib
 microarch_level:
-- '1'
+- '3'
 numpy:
 - '2'
 pin_run_as_build:
@@ -35,9 +35,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.10.* *_cpython
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,11 +15,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
@@ -27,7 +27,7 @@ libblas:
 liblapacke:
 - 3.9.* *netlib
 microarch_level:
-- '1'
+- '3'
 numpy:
 - '2'
 pin_run_as_build:
@@ -35,9 +35,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.11.* *_cpython
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.12.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,11 +15,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
@@ -27,7 +27,7 @@ libblas:
 liblapacke:
 - 3.9.* *netlib
 microarch_level:
-- '1'
+- '3'
 numpy:
 - '2'
 pin_run_as_build:
@@ -35,9 +35,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.12.* *_cpython
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.13.____cp313.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '13'
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,17 +15,19 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.6'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '13'
+- '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '3'
 numpy:
 - '2'
 pin_run_as_build:
@@ -33,7 +35,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.13.* *_cp313
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,11 +15,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
@@ -27,7 +27,7 @@ libblas:
 liblapacke:
 - 3.9.* *netlib
 microarch_level:
-- '1'
+- '4'
 numpy:
 - '2'
 pin_run_as_build:
@@ -35,9 +35,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.10.* *_cpython
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,11 +15,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
@@ -27,7 +27,7 @@ libblas:
 liblapacke:
 - 3.9.* *netlib
 microarch_level:
-- '1'
+- '4'
 numpy:
 - '2'
 pin_run_as_build:
@@ -35,9 +35,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.11.* *_cpython
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.12.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '13'
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,17 +15,19 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.6'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '13'
+- '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '4'
 numpy:
 - '2'
 pin_run_as_build:
@@ -33,7 +35,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.12.* *_cpython
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.13.____cp313.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,11 +15,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libblas:
@@ -27,7 +27,7 @@ libblas:
 liblapacke:
 - 3.9.* *netlib
 microarch_level:
-- '1'
+- '4'
 numpy:
 - '2'
 pin_run_as_build:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.13.* *_cp313
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython.yaml
@@ -26,6 +26,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython.yaml
@@ -26,6 +26,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython.yaml
@@ -26,6 +26,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313.yaml
@@ -26,6 +26,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.10.____cpython.yaml
@@ -26,6 +26,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.11.____cpython.yaml
@@ -26,6 +26,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.12.____cpython.yaml
@@ -26,6 +26,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.13.____cp313.yaml
@@ -26,6 +26,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compiler_version12.4cxx_compiler_version12python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compiler_version12.4cxx_compiler_version12python3.10.____cpython.yaml
@@ -26,6 +26,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compiler_version12.4cxx_compiler_version12python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compiler_version12.4cxx_compiler_version12python3.11.____cpython.yaml
@@ -26,6 +26,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compiler_version12.4cxx_compiler_version12python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compiler_version12.4cxx_compiler_version12python3.12.____cpython.yaml
@@ -26,6 +26,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.10.____cpython.yaml
@@ -26,6 +26,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.11.____cpython.yaml
@@ -26,6 +26,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.12.____cpython.yaml
@@ -26,6 +26,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.13.____cp313.yaml
@@ -26,6 +26,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/osx_64_microarch_level1python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level1python3.10.____cpython.yaml
@@ -1,13 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,17 +17,17 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
 - '1'
 numpy:
@@ -35,10 +37,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.10.* *_cpython
 target_platform:
-- linux-ppc64le
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/osx_64_microarch_level1python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level1python3.11.____cpython.yaml
@@ -1,13 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '13'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,17 +17,19 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.6'
+- None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '13'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:
@@ -33,10 +37,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.11.* *_cpython
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/osx_64_microarch_level1python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level1python3.12.____cpython.yaml
@@ -1,13 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,17 +17,17 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
 - '1'
 numpy:
@@ -35,10 +37,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.12.* *_cpython
 target_platform:
-- linux-ppc64le
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/osx_64_microarch_level1python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_microarch_level1python3.13.____cp313.yaml
@@ -1,13 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,17 +17,17 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
 - '1'
 numpy:
@@ -37,8 +39,7 @@ pin_run_as_build:
 python:
 - 3.13.* *_cp313
 target_platform:
-- linux-ppc64le
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/osx_64_microarch_level3python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level3python3.10.____cpython.yaml
@@ -1,13 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,19 +17,19 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
-- '1'
+- '3'
 numpy:
 - '2'
 pin_run_as_build:
@@ -35,10 +37,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.10.* *_cpython
 target_platform:
-- linux-ppc64le
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/osx_64_microarch_level3python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level3python3.11.____cpython.yaml
@@ -1,13 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,19 +17,19 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
-- '1'
+- '3'
 numpy:
 - '2'
 pin_run_as_build:
@@ -35,10 +37,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.11.* *_cpython
 target_platform:
-- linux-ppc64le
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/osx_64_microarch_level3python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level3python3.12.____cpython.yaml
@@ -1,13 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,19 +17,19 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
-- '1'
+- '3'
 numpy:
 - '2'
 pin_run_as_build:
@@ -35,10 +37,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.12.* *_cpython
 target_platform:
-- linux-ppc64le
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/osx_64_microarch_level3python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_microarch_level3python3.13.____cp313.yaml
@@ -1,13 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '14'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,15 +19,17 @@ cuda_compiler:
 cuda_compiler_version:
 - None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '14'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
+microarch_level:
+- '3'
 numpy:
 - '2'
 pin_run_as_build:
@@ -33,10 +37,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.13.* *_cp313
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/osx_64_microarch_level4python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level4python3.10.____cpython.yaml
@@ -1,13 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,19 +17,19 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
-- '1'
+- '4'
 numpy:
 - '2'
 pin_run_as_build:
@@ -35,10 +37,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.10.* *_cpython
 target_platform:
-- linux-ppc64le
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/osx_64_microarch_level4python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level4python3.11.____cpython.yaml
@@ -1,13 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '13'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,17 +17,19 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.6'
+- None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '13'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
+microarch_level:
+- '4'
 numpy:
 - '2'
 pin_run_as_build:
@@ -33,10 +37,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.11.* *_cpython
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/osx_64_microarch_level4python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level4python3.12.____cpython.yaml
@@ -1,13 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,19 +17,19 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.4'
+- None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
-- '1'
+- '4'
 numpy:
 - '2'
 pin_run_as_build:
@@ -35,10 +37,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.12.* *_cpython
 target_platform:
-- linux-ppc64le
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/osx_64_microarch_level4python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_microarch_level4python3.13.____cp313.yaml
@@ -1,13 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '14'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,15 +19,17 @@ cuda_compiler:
 cuda_compiler_version:
 - None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '14'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
+microarch_level:
+- '4'
 numpy:
 - '2'
 pin_run_as_build:
@@ -33,10 +37,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.13.* *_cp313
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -28,6 +28,8 @@ liblapacke:
 - 3.9.* *netlib
 macos_machine:
 - arm64-apple-darwin20.0.0
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -28,6 +28,8 @@ liblapacke:
 - 3.9.* *netlib
 macos_machine:
 - arm64-apple-darwin20.0.0
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -28,6 +28,8 @@ liblapacke:
 - 3.9.* *netlib
 macos_machine:
 - arm64-apple-darwin20.0.0
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -28,6 +28,8 @@ liblapacke:
 - 3.9.* *netlib
 macos_machine:
 - arm64-apple-darwin20.0.0
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version12.6python3.10.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.6python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version12.6python3.11.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.6python3.11.____cpython.yaml
@@ -16,6 +16,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version12.6python3.12.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.6python3.12.____cpython.yaml
@@ -16,6 +16,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_version12.6python3.13.____cp313.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.6python3.13.____cp313.yaml
@@ -16,6 +16,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.10.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.10.____cpython.yaml
@@ -16,6 +16,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.11.____cpython.yaml
@@ -16,6 +16,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpython.yaml
@@ -16,6 +16,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/.ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313.yaml
+++ b/.ci_support/win_64_cuda_compiler_versionNonepython3.13.____cp313.yaml
@@ -16,6 +16,8 @@ libblas:
 - 3.9.* *netlib
 liblapacke:
 - 3.9.* *netlib
+microarch_level:
+- '1'
 numpy:
 - '2'
 pin_run_as_build:

--- a/README.md
+++ b/README.md
@@ -57,59 +57,171 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython</td>
+              <td>linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython</td>
+              <td>linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython</td>
+              <td>linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.12.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313</td>
+              <td>linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.13.____cp313</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level1python3.13.____cp313" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.10.____cpython</td>
+              <td>linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.11.____cpython</td>
+              <td>linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.12.____cpython</td>
+              <td>linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.12.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.13.____cp313</td>
+              <td>linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.13.____cp313</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14python3.13.____cp313" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level3python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13microarch_level4python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level1python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level3python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version14cuda_compiler_versionNonecxx_compiler_version14microarch_level4python3.13.____cp313" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -225,31 +337,87 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python3.10.____cpython</td>
+              <td>osx_64_microarch_level1python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level1python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python3.11.____cpython</td>
+              <td>osx_64_microarch_level1python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level1python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python3.12.____cpython</td>
+              <td>osx_64_microarch_level1python3.12.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level1python3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python3.13.____cp313</td>
+              <td>osx_64_microarch_level1python3.13.____cp313</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.13.____cp313" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level1python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level3python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level3python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level3python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level3python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level4python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level4python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level4python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level4python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level4python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level4python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level4python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26153&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastemriwaveforms-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level4python3.13.____cp313" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+microarch_level:
+   - 1
+   - 3  # [unix and x86_64]
+   - 4  # [unix and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "FastEMRIWaveforms" %}
 {% set version = "2.0.0" %}
+{% set build = 3 %}
 
 {% set PYTHON = "python" %}
 {% set PYTHON = "$PREFIX/bin/python" %}  # [linux]
@@ -21,9 +22,14 @@ package:
 source:
   url: https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms/archive/refs/tags/v{{ version }}.tar.gz
   sha256: d5c8bcba1ec24cb71be8a293f75cf1491e2e474515c1481559a4ef07378e0c36
+  patches:
+    - patches/01_few2.0_march.patch
 
 build:
-  number: 2
+  number: {{ build }}          # [not (unix and x86_64)]
+  number: {{ build + 100 }}    # [unix and x86_64 and microarch_level == 1]
+  number: {{ build + 300 }}    # [unix and x86_64 and microarch_level == 3]
+  number: {{ build + 400 }}    # [unix and x86_64 and microarch_level == 4]
   skip: True  # [(py<310)]
 
 outputs:
@@ -34,8 +40,12 @@ outputs:
       script_env:
         - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
       script:
-        - >-
-          {{ PYTHON }} -m pip install . -vv -Ccmake.define.FEW_LAPACKE_FETCH=OFF -Ccmake.define.FEW_WITH_GPU=OFF -Ccmake.define.FEW_LAPACKE_DETECT_WITH=PKGCONFIG
+        - >
+          {{ PYTHON }} -m pip install . -vv 
+          -Ccmake.define.FEW_LAPACKE_FETCH=OFF
+          -Ccmake.define.FEW_WITH_GPU=OFF
+          -Ccmake.define.FEW_LAPACKE_DETECT_WITH=PKGCONFIG
+          -Ccmake.define.FEW_MARCH=x86-64-v{{ microarch_level }}  # [unix and x86_64]
       entry_points:
         - few_citations = few.cmd.citations:main
         - few_files = few.cmd.files:main
@@ -56,6 +66,7 @@ outputs:
         - cmake
         - pkg-config
         - make
+        - x86_64-microarch-level {{ microarch_level }}  # [unix and x86_64 and microarch_level < 4]
       host:
         - python
         - pip
@@ -85,6 +96,7 @@ outputs:
         - scipy
         - tqdm
         - wrapt
+        - _x86_64-microarch-level {{ microarch_level }}  # [unix and x86_64 and microarch_level == 4]
     test:
       imports:
         - few
@@ -95,8 +107,8 @@ outputs:
       commands:
         - pip check
         - python -c "import importlib.metadata; assert importlib.metadata.version('fastemriwaveforms') == '{{ version }}'"
-        - python -c "import few; few.get_backend('cpu')"
-        - python -m few.tests --disable testfile
+        - python -c "import few; few.get_backend('cpu')"  # [microarch_level < 4]
+        - python -m few.tests --disable testfile  # [microarch_level < 4]
     about:
       home: https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms
       summary: 'Blazingly fast EMRI waveforms'
@@ -113,7 +125,7 @@ outputs:
   - name: fastemriwaveforms-cuda12x
     version: {{ version }}
     build:
-      skip: true  # [(py<310) or (cuda_major == 0) or not linux]
+      skip: true  # [(py<310) or (cuda_major == 0) or not linux or (microarch_level != 1)]
       script_env:
         - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
       script:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -107,7 +107,7 @@ outputs:
       requires:
         - pip  # [microarch_level < 4]
       commands:
-        - pip check
+        - pip check  # [microarch_level < 4]
         - python -c "import importlib.metadata; assert importlib.metadata.version('fastemriwaveforms') == '{{ version }}'"  # [microarch_level < 4]
         - python -c "import few; few.get_backend('cpu')"  # [microarch_level < 4]
         - python -m few.tests --disable testfile  # [microarch_level < 4]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -97,6 +97,7 @@ outputs:
         - tqdm
         - wrapt
         - _x86_64-microarch-level {{ microarch_level }}  # [unix and x86_64 and microarch_level == 4]
+{% if microarch_level < 4 %}
     test:
       imports:
         - few
@@ -107,8 +108,9 @@ outputs:
       commands:
         - pip check
         - python -c "import importlib.metadata; assert importlib.metadata.version('fastemriwaveforms') == '{{ version }}'"
-        - python -c "import few; few.get_backend('cpu')"  # [microarch_level < 4]
-        - python -m few.tests --disable testfile  # [microarch_level < 4]
+        - python -c "import few; few.get_backend('cpu')"
+        - python -m few.tests --disable testfile
+{% endif %}
     about:
       home: https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms
       summary: 'Blazingly fast EMRI waveforms'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,11 @@
 {% set microarch_level = 1 %}
 {% endif %}
 
+{% set build_with_microarch = build + 100 %}  # [microarch_level == 1]
+{% set build_with_microarch = build + 300 %}  # [microarch_level == 3]
+{% set build_with_microarch = build + 400 %}  # [microarch_level == 4]
+
+
 
 package:
   name: {{ name|lower }}-split
@@ -31,7 +36,7 @@ source:
     - patches/01_few2.0_march.patch
 
 build:
-  number: {{ build + (microarch_level | int - 1) * 100 }}
+  number: {{ build_with_microarch }}
   skip: True  # [(py<310)]
 
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,11 @@
 {% set cuda_major = environ.get("cuda_compiler_version", "11.8").split(".")[0] | int %}
 {% endif %}
 
+{% if microarch_level is undefined %}
+{% set microarch_level = 1 %}
+{% endif %}
+
+
 package:
   name: {{ name|lower }}-split
   version: {{ version }}
@@ -26,10 +31,7 @@ source:
     - patches/01_few2.0_march.patch
 
 build:
-  number: {{ build }}          # [not (unix and x86_64)]
-  number: {{ build + 100 }}    # [unix and x86_64 and microarch_level == 1]
-  number: {{ build + 300 }}    # [unix and x86_64 and microarch_level == 3]
-  number: {{ build + 400 }}    # [unix and x86_64 and microarch_level == 4]
+  number: {{ build + (microarch_level | int - 1) * 100 }}
   skip: True  # [(py<310)]
 
 outputs:
@@ -97,20 +99,18 @@ outputs:
         - tqdm
         - wrapt
         - _x86_64-microarch-level {{ microarch_level }}  # [unix and x86_64 and microarch_level == 4]
-{% if microarch_level < 4 %}
     test:
       imports:
-        - few
-        - few.tests
-        - few_backend_cpu
+        - few  # [microarch_level < 4]
+        - few.tests  # [microarch_level < 4]
+        - few_backend_cpu  # [microarch_level < 4]
       requires:
-        - pip
+        - pip  # [microarch_level < 4]
       commands:
         - pip check
-        - python -c "import importlib.metadata; assert importlib.metadata.version('fastemriwaveforms') == '{{ version }}'"
-        - python -c "import few; few.get_backend('cpu')"
-        - python -m few.tests --disable testfile
-{% endif %}
+        - python -c "import importlib.metadata; assert importlib.metadata.version('fastemriwaveforms') == '{{ version }}'"  # [microarch_level < 4]
+        - python -c "import few; few.get_backend('cpu')"  # [microarch_level < 4]
+        - python -m few.tests --disable testfile  # [microarch_level < 4]
     about:
       home: https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms
       summary: 'Blazingly fast EMRI waveforms'

--- a/recipe/patches/01_few2.0_march.patch
+++ b/recipe/patches/01_few2.0_march.patch
@@ -1,0 +1,51 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index aea8908..666d04a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -38,6 +38,9 @@ set(FEW_CUDA_ARCH "native"
+     CACHE STRING "CUDA Architecture targetted for FEW compilation (see doc of \
+           CMAKE_CUDA_ARCHITECTURES).")
+ 
++set(FEW_MARCH "native"
++    CACHE STRING "Value of the -march compiler option if supported by compiler")
++
+ # FEW_LAPACKE_DETECT_WITH sets the tool used to try to detect LAPACKE locally.
+ # Possible values are:
+ #
+@@ -88,6 +91,20 @@ add_library(fastemriwaveforms INTERFACE)
+ # ---- Enable building the CPU version of backends by default ----
+ set_target_properties(fastemriwaveforms PROPERTIES WITH_CPU ON)
+ 
++# ---- Test whether the FEW_MARCH option is supported by CXX compiler ----
++include(CheckCXXCompilerFlag)
++set(FEW_MARCH_CXX_OPT "-march=${FEW_MARCH}")
++check_cxx_compiler_flag("${FEW_MARCH_CXX_OPT}" CXX_COMPILER_SUPPORTS_FEW_MARCH)
++if(CXX_COMPILER_SUPPORTS_FEW_MARCH)
++  set_property(TARGET fastemriwaveforms PROPERTY CXX_MARCH
++                                                 "${FEW_MARCH_CXX_OPT}")
++  message(STATUS "The CXX compiler supports option '${FEW_MARCH_CXX_OPT}'.")
++else()
++  message(
++    WARNING "The CXX compiler does not support option '${FEW_MARCH_CXX_OPT}'. \
++      It will be ignored.")
++endif()
++
+ # ---- Optionnally check if GPU is supported ----
+ if(FEW_WITH_GPU STREQUAL "AUTO")
+   if(DEFINED ENV{READTHEDOCS})
+diff --git a/src/few/cutils/CMakeLists.txt b/src/few/cutils/CMakeLists.txt
+index cafe198..3c0feb1 100644
+--- a/src/few/cutils/CMakeLists.txt
++++ b/src/few/cutils/CMakeLists.txt
+@@ -317,6 +317,11 @@ function(apply_cpu_backend_common_options libname)
+ 
+   install(TARGETS ${target_name} DESTINATION few_backend_cpu)
+ 
++  get_target_property(FEW_CXX_MARCH_OPT fastemriwaveforms CXX_MARCH)
++  if(FEW_CXX_MARCH_OPT)
++    target_compile_options(${target_name} PRIVATE "${FEW_CXX_MARCH_OPT}")
++  endif()
++
+   target_include_directories(${target_name} PRIVATE ${Python_NumPy_INCLUDE_DIR})
+   target_compile_definitions(${target_name}
+                              PRIVATE NPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR attempts to build the CPU package for multiple architecture specification on unix platforms with x86-64 cpus. These packages target the `x86-64-v1`, `x86-64-v2` and the `x86-64-v4` feature sets through the `-march` compilation option.

The selected approach follows the [Knowledge Base docs on "Microarchitecture-optimized builds"](https://conda-forge.org/docs/maintainer/knowledge_base/#microarch).