### PR TITLE
fix: ensure cuda12x variant is built

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ inspiral (EMRI) waveforms. This is the core package with only CPU support
 for waveform generation.
 
 
+About fastemriwaveforms-cuda12x
+-------------------------------
+
+Home: https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms
+
+Package license: GPL-3.0-or-later
+
+Summary: Blazingly fast EMRI waveforms
+
+Development: https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms
+
+Documentation: https://fastemriwaveforms.readthedocs.io/en/v2.0.0/
+
+This package contains the highly modular framework for fast and accurate extreme mass ratio
+inspiral (EMRI) waveforms. This is the CUDA plugin package which adds GPU acceleration
+to the waveform generation.
+
+
 Current build status
 ====================
 
@@ -518,6 +536,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-fastemriwaveforms-green.svg)](https://anaconda.org/conda-forge/fastemriwaveforms) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/fastemriwaveforms.svg)](https://anaconda.org/conda-forge/fastemriwaveforms) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/fastemriwaveforms.svg)](https://anaconda.org/conda-forge/fastemriwaveforms) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/fastemriwaveforms.svg)](https://anaconda.org/conda-forge/fastemriwaveforms) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-fastemriwaveforms--cuda12x-green.svg)](https://anaconda.org/conda-forge/fastemriwaveforms-cuda12x) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/fastemriwaveforms-cuda12x.svg)](https://anaconda.org/conda-forge/fastemriwaveforms-cuda12x) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/fastemriwaveforms-cuda12x.svg)](https://anaconda.org/conda-forge/fastemriwaveforms-cuda12x) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/fastemriwaveforms-cuda12x.svg)](https://anaconda.org/conda-forge/fastemriwaveforms-cuda12x) |
 
 Installing fastemriwaveforms
 ============================
@@ -529,16 +548,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `fastemriwaveforms` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `fastemriwaveforms, fastemriwaveforms-cuda12x` can be installed with `conda`:
 
 ```
-conda install fastemriwaveforms
+conda install fastemriwaveforms fastemriwaveforms-cuda12x
 ```
 
 or with `mamba`:
 
 ```
-mamba install fastemriwaveforms
+mamba install fastemriwaveforms fastemriwaveforms-cuda12x
 ```
 
 It is possible to list all of the versions of `fastemriwaveforms` available on your platform with `conda`:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,5 @@
 microarch_level:
-   - 1
-   - 3  # [unix and x86_64]
-   - 4  # [unix and x86_64]
+  - 1
+  - 3  # [unix and x86_64]
+  - 4  # [unix and x86_64]
+  

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "FastEMRIWaveforms" %}
 {% set version = "2.0.0" %}
-{% set build = 3 %}
+{% set build = 4 %}
 
 {% set PYTHON = "python" %}
 {% set PYTHON = "$PREFIX/bin/python" %}  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@
 {% set RECIPE_DIR = "%RECIPE_DIR%\\" %}  # [win]
 
 {% if cuda_compiler_version in (None, "None", True, False) %}
-{% set cuda_major = 0 %}
+{% set cuda_major = 0 | int %}
 {% else %}
 {% set cuda_major = environ.get("cuda_compiler_version", "11.8").split(".")[0] | int %}
 {% endif %}
@@ -132,7 +132,7 @@ outputs:
   - name: fastemriwaveforms-cuda12x
     version: {{ version }}
     build:
-      skip: true  # [(py<310) or (cuda_major == 0) or not linux or (microarch_level != 1)]
+      skip: true  # [(py<310) or (cuda_compiler_version != None) or not linux]
       script_env:
         - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
       script:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -132,7 +132,7 @@ outputs:
   - name: fastemriwaveforms-cuda12x
     version: {{ version }}
     build:
-      skip: true  # [(py<310) or (cuda_compiler_version != None) or not linux]
+      skip: true  # [(py<310) or (cuda_compiler_version in (None, 'None')) or not linux]
       script_env:
         - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
       script:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -132,7 +132,7 @@ outputs:
   - name: fastemriwaveforms-cuda12x
     version: {{ version }}
     build:
-      skip: true  # [(py<310) or (cuda_compiler_version in (None, 'None')) or not linux]
+      skip: true  # [(py<310) or (cuda_compiler_version in (None, 'None')) or not linux or (microarch_level != 1)]
       script_env:
         - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
       script:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

The fixes in #2 to build the package on all platforms inadvertently disabled the builds of the `fastemriwaveforms-cuda12x` subpackage.
This PR aims to fix this issue.
