### PR TITLE
feat: try changing the way cuda12x package pins the core one

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -188,7 +188,7 @@ outputs:
 
       run:
         - python
-        - {{ pin_subpackage('fastemriwaveforms', exact=True) }}
+        - {{ pin_subpackage('fastemriwaveforms', min_pin='x.x.x', max_pin='x.x.x') }}
         - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
         - cupy
         - cuda-cudart


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Currently, the `fastemriwaveforms-cuda12x` pins the core package with `fastemriwaveforms` with the `exact=True` argument which prevents compatibility between the `microarch_level=1` cuda12x package with a core package of other level.
This PR tries to fix this.