### PR TITLE
feat: drop CUDA support on ppc64le architecture

### DIFF
--- a/.ci_support/linux_ppc64le_c_compiler_version12cxx_compiler_version12python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cxx_compiler_version12python3.10.____cpython.yaml
@@ -12,10 +12,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cuda_compiler:
-- cuda-nvcc
-cuda_compiler_version:
-- '12.4'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -41,4 +37,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/linux_ppc64le_c_compiler_version12cxx_compiler_version12python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cxx_compiler_version12python3.11.____cpython.yaml
@@ -12,10 +12,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cuda_compiler:
-- cuda-nvcc
-cuda_compiler_version:
-- '12.4'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -41,4 +37,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/linux_ppc64le_c_compiler_version12cxx_compiler_version12python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cxx_compiler_version12python3.12.____cpython.yaml
@@ -12,10 +12,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cuda_compiler:
-- cuda-nvcc
-cuda_compiler_version:
-- '12.4'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -41,4 +37,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/linux_ppc64le_c_compiler_version12cxx_compiler_version12python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cxx_compiler_version12python3.13.____cp313.yaml
@@ -12,10 +12,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cuda_compiler:
-- cuda-nvcc
-cuda_compiler_version:
-- '12.4'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -41,4 +37,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/linux_ppc64le_c_compiler_version14cxx_compiler_version14python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version14cxx_compiler_version14python3.10.____cpython.yaml
@@ -12,10 +12,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cuda_compiler:
-- cuda-nvcc
-cuda_compiler_version:
-- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -41,4 +37,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/linux_ppc64le_c_compiler_version14cxx_compiler_version14python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version14cxx_compiler_version14python3.11.____cpython.yaml
@@ -12,10 +12,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cuda_compiler:
-- cuda-nvcc
-cuda_compiler_version:
-- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -41,4 +37,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/linux_ppc64le_c_compiler_version14cxx_compiler_version14python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version14cxx_compiler_version14python3.12.____cpython.yaml
@@ -12,10 +12,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cuda_compiler:
-- cuda-nvcc
-cuda_compiler_version:
-- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -41,4 +37,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/.ci_support/linux_ppc64le_c_compiler_version14cxx_compiler_version14python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version14cxx_compiler_version14python3.13.____cp313.yaml
@@ -12,10 +12,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cuda_compiler:
-- cuda-nvcc
-cuda_compiler_version:
-- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -41,4 +37,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - cuda_compiler_version

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 context:
   name: FastEMRIWaveforms
   version: 2.0.0
-  build: 9
+  build: 10
   RECIPE_DIR: ${{ env.get("RECIPE_DIR", default=".") }}
   cuda_major: ${{ env.get("cuda_compiler_version", default="0.0") | split(".") | first | int }}
   microarch_level: ${{ 1 if microarch_level is undefined else microarch_level }}
@@ -129,7 +129,7 @@ outputs:
       name: fastemriwaveforms-cuda12x
       version: ${{ version }}
     build:
-      skip: (match(python, "<3.10")) or (cuda_compiler_version in (None, 'None')) or not linux
+      skip: (match(python, "<3.10")) or (cuda_compiler_version in (None, 'None')) or not linux or ppc64le
       script:
         env:
           SETUPTOOLS_SCM_PRETEND_VERSION: ${{ version }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR disables building the `fastemriwaveforms-cuda12x` package for `linux-ppc64le` architecture since its support was [deprecated with CUDA 12.4](https://docs.nvidia.com/cuda/archive/12.4.0/cuda-toolkit-release-notes/index.html#deprecated-architectures) and dropped in 12.5.